### PR TITLE
Allow only one statement per line

### DIFF
--- a/common.js
+++ b/common.js
@@ -25,6 +25,7 @@ module.exports = {
     'jsx-quotes': ['error', 'prefer-single'],
     'key-spacing': 'error',
     'keyword-spacing': 'error',
+    'max-statements-per-line': 'error',
     'multiline-comment-style': 'error',
     'new-cap': 'error',
     'no-alert': 'error',


### PR DESCRIPTION
Add rule `max-statements-per-line` with error level, to fix cases where a semicolon is used on a line to separate two statements.

For example, the following code will throw an error:
`let a; let b;`

And should be changed for:
```
let a;
let b;
```