### PR TITLE
Add react/sort-comp rule for React

### DIFF
--- a/react.js
+++ b/react.js
@@ -22,6 +22,7 @@ module.exports = {
     'react/display-name': 'off',
     'react/no-unused-prop-types': 'error',
     'react/no-unused-state': 'error',
-    'react/jsx-first-prop-new-line': ['error', 'multiline']
+    'react/jsx-first-prop-new-line': ['error', 'multiline'],
+    'react/sort-comp': 'error'
   }
 }


### PR DESCRIPTION
# Context
We want to be able to enforce consistent method order in our react components. Here's the rule to accomplish that:
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md

For now we'll just use the default configuration.