### PR TITLE
Disallow spaces inside of parentheses

### DIFF
--- a/common.js
+++ b/common.js
@@ -54,6 +54,7 @@ module.exports = {
     'quote-props': ['error', 'consistent-as-needed'],
     'quotes': ['error', 'single', 'avoid-escape'],
     'space-before-blocks': 'error',
-    'space-infix-ops': 'error'
+    'space-infix-ops': 'error',
+    'space-in-parens': 'error'
   }
 }


### PR DESCRIPTION
Add rule `space-in-parens` with error level to avoid unexpected spaces inside parentheses.

Error example code: 
```
foo( 'bar');
```

Correct example code: 
```
foo('bar');
```

Reference: https://github.com/edlio/websearch-index/pull/24#discussion_r333727591