### PR TITLE
Add no-restricted-modules rule to node.js

### DIFF
--- a/node.js
+++ b/node.js
@@ -1,4 +1,4 @@
-const restrictedModuleMessage = 'If your PR introduces this module as a new dependency please use node-fetch instead; Otherwise do not try to refactor and ignore this warning.'
+const restrictedModulesMessage = 'If your PR introduces this module as a new dependency please use node-fetch instead; Otherwise do not try to refactor and ignore this warning.'
 
 module.exports = {
   env: {

--- a/node.js
+++ b/node.js
@@ -1,5 +1,5 @@
 const restrictedModuleMessage = module => (
-  `${module} module is restricted. If your PR introduces this module as a new dependency please use node-fetch instead; Otherwise do not try to refactor and you can ignore this warning.`
+  `${module} module is restricted. If your PR introduces this module as a new dependency please use node-fetch instead; Otherwise do not try to refactor and ignore this warning.`
 )
 
 module.exports = {

--- a/node.js
+++ b/node.js
@@ -1,6 +1,4 @@
-const restrictedModuleMessage = module => (
-  `${module} module is restricted. If your PR introduces this module as a new dependency please use node-fetch instead; Otherwise do not try to refactor and ignore this warning.`
-)
+const restrictedModuleMessage = 'If your PR introduces this module as a new dependency please use node-fetch instead; Otherwise do not try to refactor and ignore this warning.'
 
 module.exports = {
   env: {
@@ -14,8 +12,8 @@ module.exports = {
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
     'no-restricted-modules': ['warn', {
       paths: [
-        { name: 'request', message: restrictedModuleMessage('request') },
-        { name: 'axios', message: restrictedModuleMessage('axios') }
+        { name: 'request', message: restrictedModulesMessage },
+        { name: 'axios', message: restrictedModulesMessage }
       ]
     }]
   }

--- a/node.js
+++ b/node.js
@@ -1,3 +1,7 @@
+const restrictedModuleMessage = module => (
+  `${module} module is restricted. If your PR introduces this module as a new dependency please use node-fetch instead; Otherwise do not try to refactor and you can ignore this warning.`
+)
+
 module.exports = {
   env: {
     node: true,
@@ -7,6 +11,12 @@ module.exports = {
   ],
   rules: {
     // Allow _id, as its part of Mongo id
-    'no-underscore-dangle': ['error', { allow: ['_id'] }]
+    'no-underscore-dangle': ['error', { allow: ['_id'] }],
+    'no-restricted-modules': ['error', {
+      paths: [
+        { name: 'request', message: restrictedModuleMessage('request') },
+        { name: 'axios', message: restrictedModuleMessage('axios') }
+      ]
+    }]
   }
 }

--- a/node.js
+++ b/node.js
@@ -12,7 +12,7 @@ module.exports = {
   rules: {
     // Allow _id, as its part of Mongo id
     'no-underscore-dangle': ['error', { allow: ['_id'] }],
-    'no-restricted-modules': ['error', {
+    'no-restricted-modules': ['warn', {
       paths: [
         { name: 'request', message: restrictedModuleMessage('request') },
         { name: 'axios', message: restrictedModuleMessage('axios') }


### PR DESCRIPTION
We would like to prevent this modules being added as new dependencies. However if they are already part of the package.json we don't want our developers to go and refactor all the code, so this PR introduces a new warning using `no-restricted-modules` rule for `axios` and `request` packages. 