### PR TITLE
Allow string literals/backticks on quotes

### DIFF
--- a/common.js
+++ b/common.js
@@ -45,7 +45,7 @@ module.exports = {
     'prefer-arrow-callback': 'error',
     'prefer-const': 'error',
     'quote-props': ['error', 'consistent-as-needed'],
-    'quotes': ['error', 'single', 'avoid-escape'],
+    'quotes': ['error', 'single', 'avoid-escape', {'allowTemplateLiterals': true}],
     'space-before-blocks': 'error',
     'space-in-parens': 'error',
     'space-infix-ops': 'error'


### PR DESCRIPTION
Configuring eslint so it that will allow the use of String Literals (`) on quotes so that we don't have to worry about escaping single or double quotes.

(Need to test this change)